### PR TITLE
Shettles' R1-vegClass Commits

### DIFF
--- a/packages/vegClass/R/DOM6040.R
+++ b/packages/vegClass/R/DOM6040.R
@@ -1,0 +1,188 @@
+################################################################################
+#Function: computeDominance6040
+#
+#Calculates dominance group 6040
+#
+#Arguments
+#
+#dTotal:  Stand-level trees per acre
+#
+#spec1:   Character vector of species in the stand (USDA Plants 4-digit code(s))
+#
+#prop1:   Numeric vector of the proportions of TPA/BA by species in the stand
+#
+#diam1:   Numeric vector of the basal area weighted average diameters by species
+#         in the stand
+#
+#height1: Numeric vector of the arithmetic/basal area weighted average heights
+#         by species in the stand
+#
+#Return value
+#
+# - DOM6040
+################################################################################
+
+
+# create data dictionaries for species, dominance class and covertype mapping
+     MapSpecies <- c(
+       "GF"="ABGR", "BA"="POPUL", "CW"="POPUL", "NC"="POPUL",
+       "PW"="POPUL", "GA"="FRPE", "AF"="ABLA", "L"="LAOC",
+       "WB"="PIAL", "S"="PIEN", "LP"="PICO", "WP"="PIMO3",
+       "PP"="PIPO", "DF"="PSME", "C"="THPL", "WH"="TSHE",
+       "LM"="PIFL2", "LL"="LALY", "JU"="JUNIP","RM"="JUNIP",
+       "PB"="BEPA", "CO"="POPUL", "AS"="POTR5", "OH"="2TREE",
+       "OS"="2TREE", "MH"="TSME", "PI"="2TREE", "OT"="2TREE",
+       "WL"="LAOC", "ES"="PIEN", "RC"="THPL", "MM"="ACER",
+       "ACGL"="ACER", "ACGR3"="ACER","PY"="TABR2", "TABR2"="TABR2",
+       "ABGR"= "ABGR", "ABCO"="ABGR", "ABLA"="ABLA", "LAOC"="LAOC",
+       "PIAL"="PIAL", "PIEN"="PIEN", "PIGL"="PIEN","PICO"="PICO",
+       "PIMO3"="PIMO3", "PIPO"="PIPO", "PSME"="PSME", "THPL"="THPL",
+       "TSHE"="TSHE", "PIFL2"="PIFL2", "LALY"="LALY", "JUNIP"="JUNIP",
+       "JUOC"="JUNIP", "JUOS"="JUNIP", "JUSC2"="JUNIP", "BEPA"="BEPA",
+       "BEGL"="BEPA", "BEOC2"="BEPA", "BETUL"="BEPA", "POPUL"="POPUL",
+       "POBA2"="POPUL", "PODEM"="POPUL", "POTR15"="POPUL", "POAN3"="POPUL",
+       "POBAT"="POPUL", "POTR5"="POTR5", "2TREE"="2TREE", "2TE"="2TREE",
+       "2DE"="2TREE", "CELE3"="CELE3", "TSME"="TSME", "FRPE"="FRPE",
+       "ALRU2"="ALDER", "ALRH"="ALDER"
+      )
+      MapDominance6040SpeciestoSubclass <- c(
+       "2TD"="HMIX", "2TE"="IMIX", "2TREE"="IMIX", "ABCO"="TMIX",
+       "ABGR"="TMIX", "ABLA"="TMIX", "ACER"="HMIX", "ALDER"="HMIX",
+       "ALRH2"="HMIX", "ALRU2"="HMIX", "BEGL"="HMIX", "BEOC2"="HMIX",
+       "BEPA"="HMIX", "BETUL"="HMIX", "CELE3"="IMIX", "FRPE"="HMIX",
+       "JUNIP"="IMIX", "JUOC"="IMIX", "JUOS"="IMIX", "JUSC2"="IMIX",
+       "LALY"="IMIX", "LAOC"="IMIX", "PIAL"="IMIX", "PICO"="IMIX",
+       "PIEN"="TMIX", "PIFL2"="IMIX", "PIGL"="TMIX", "PIMO3"="IMIX",
+       "PIPO"="IMIX", "POAN3"="HMIX", "POBA2"="HMIX", "POBAT"="HMIX",
+       "PODEM"="HMIX", "POPUL"="HMIX", "POTR15"="HMIX", "POTR5"="HMIX",
+       "PSME"="IMIX", "TABR2"="TMIX", "THPL"="TMIX", "TSHE"="TMIX",
+       "TSME"="TMIX", "AF"="TMIX", "AS"="HMIX", "BA"="HMIX",
+       "CW"="HMIX", "DF"="IMIX", "ES"="TMIX", "GA"="HMIX",
+       "GF"="TMIX", "LL"="IMIX", "LM"="IMIX", "LP"="IMIX",
+       "MH"="TMIX", "MM"="HMIX", "NC"="HMIX", "OH"="HMIX",
+       "OS"="IMIX", "PB"="HMIX", "PP"="IMIX", "PW"="HMIX",
+       "PY"="TMIX", "RC"="TMIX", "RM"="IMIX", "WB"="IMIX",
+       "WH"="TMIX", "WL"="IMIX", "WP"="IMIX","NONE"="NONE"
+      )
+
+computeDominance6040 <- function(dTotal,spec1,prop1,diam1,height1){
+
+  subclasscode <- ""
+  collapsedproportion <- 0.0
+  # This orders the stands based on proportion, with proportion of 1 being
+  # the largest
+  collapsedproportion <- 0.0
+  if(length(prop1)>1){
+    for(index1 in 1:(length(prop1)-1)){
+      for(index2 in (index1+1):(length(prop1))){
+        if(prop1[index1]< prop1[index2]){
+          num1 <- prop1[index1]
+          prop1[index1] <- prop1[index2]
+          prop1[index2] <- num1
+          num2 <- height1[index1]
+          height1[index1] <- height1[index2]
+          height1[index2] <- num2
+          num3 <- diam1[index1]
+          diam1[index1] <- diam1[index2]
+          diam1[index2] <- num3
+          Str <- spec1[index1]
+          spec1[index1] <- spec1[index2]
+          spec1[index2] <- Str
+        } #if proportions are the same between 2 species, break ties based on height
+        if(prop1[index1]==prop1[index2] && height1[index1] < height1[index2]){
+          num4 <- prop1[index1]
+          prop1[index1] <- prop1[index2]
+          prop1[index2] <- num4
+          num5 <- height1[index1]
+          height1[index1] <- height1[index2]
+          height1[index2] <- num5
+          num6 <- diam1[index1]
+          diam1[index1] <- diam1[index2]
+          diam1[index2] <- num6
+          str <- spec1[index1]
+          spec1[index1] <- spec1[index2]
+          spec1[index2] <- str
+        }
+      }
+    }
+  }
+  if(prop1[1] >= 0.6){
+    DOM6040 <- as.character(MapSpecies[spec1[1]])
+    if(DOM6040=="NA" || is.na(DOM6040))DOM6040 <- "NONE"
+    collapsedproportion <- prop1[1]
+  }
+  else{
+    TmixProp <- 0.0
+    ImixProp <- 0.0
+    HmixProp <- 0.0
+    TotalMixProp <- 0.0
+    str <- ""
+    for(index in 1:(length(prop1))){
+      TotalMixProp <- TotalMixProp + prop1[index]
+      check <- match(spec1[index],as.character(MapSpecies))
+      if (!is.na(check) && check > 0){
+        key <- as.character(MapSpecies[spec1[index]])
+        if(as.character(MapDominance6040SpeciestoSubclass[key])=="TMIX"){
+          TmixProp <- TmixProp + prop1[index]
+        }
+        if(as.character(MapDominance6040SpeciestoSubclass[key])=="IMIX"){
+          ImixProp <- ImixProp + prop1[index]
+        }
+        if(as.character(MapDominance6040SpeciestoSubclass[key])=="HMIX"){
+          HmixProp <- HmixProp + prop1[index]
+        }
+      }
+    }
+
+    num11 <- 0.0
+    if(HmixProp/TotalMixProp >= 0.4){
+      str <- "HMIX"
+      num11 <- HmixProp
+    }
+    if(round((HmixProp + ImixProp)/TotalMixProp,1) >= 0.5){
+      str <- "IMIX"
+      num11 <- ImixProp
+    }
+    if(round((HmixProp + ImixProp)/TotalMixProp,1) < 0.5){
+      str <- "TMIX"
+      num11 <- TmixProp
+    }
+
+    subclasscode <- str
+    if(prop1[1] >= 0.4){
+      key <- spec1[1] #default
+      if(prop1[1]==prop1[2]){#proportions are equal - go to diameter as tie breaker
+        if(diam1[1]==diam1[2]){#diameters are equal - go to height as tie breaker
+          if(height1[1] < height1[2]) key <- spec1[2]
+          if(height1[1]==height1[2]){#heights are equal
+            check1 <- match(spec1[1],as.character(MapSpecies))#get index if spec[1] in MapSpecies
+            check2 <- match(spec1[2],as.character(MapSpecies))#get index if spec[2] in MapSpecies
+            #if both checks are not NA and spec1[1] follows spec[2] on the
+            # MapSpecies list, go with alphabetical order
+            if(!any(is.na(c(check1,check2))) && check1 > check2) key <- spec1[2]
+          }
+        }
+        else{
+          if(diam1[1] < diam1[2]) key <- spec1[2] #diameter tie breaker
+          check1 <- match(spec1[1],as.character(MapSpecies))#get index if spec[1] in MapSpecies
+          check2 <- match(spec1[2],as.character(MapSpecies))#get index if spec[2] in MapSpecies
+          #if diameters are equal, both checks are not NA, and spec1[1] follows
+          #spec[2] on the MapSpecies list, go with alphabetical order
+          if(diam1[1]==diam1[2] && !any(is.na(c(check1,check2))) && check1 > check2) key <- spec1[2]
+        }
+      }
+      DOM6040_1 <- as.character(MapSpecies[key])
+      if(DOM6040_1=="NA" || is.na(DOM6040_1)){
+        DOM6040 <- "NONE"
+        } else DOM6040 <- paste0(DOM6040_1,"-",str)
+      collapsedproportion <- prop1[1]
+    }
+    else {
+      DOM6040 <- str
+      collapsedproportion <- num11
+    }
+  }
+  if(DOM6040=="NA" || is.na(DOM6040) || length(grep("^NA",DOM6040))) DOM6040 <- "NONE"
+  subclasscode <- DOM6040
+  return(DOM6040)
+}

--- a/packages/vegClass/R/R1.R
+++ b/packages/vegClass/R/R1.R
@@ -1,0 +1,480 @@
+################################################################################
+#Function: R1
+#
+#Calculates variables previously available in the legacy R1 Existing
+#Vegetation Classifier post-processor to FVS.
+#
+#Arguments
+#
+#data:    Data frame containing tree records from a single stand or plot. Data
+#         frame must contain a column corresponding to stand/plot ID, DBH,
+#         species code (USDA plant symbol), expansion factor, and height
+#         for each tree record.
+#
+#stand:   Character string corresponding to name of column pertaining to stand
+#         or plot ID associated with tree records in data argument. By default,
+#         this value is set to "StandID".
+#
+#species: Character string corresponding to name of column pertaining to USDA
+#         plant symbols of tree records in data argument. By default, this
+#         argument is set to "SpeciesPLANTS".
+#
+#dbh:     Character string corresponding to name of column pertaining to DBH of
+#         tree records in data argument. By default, this argument is set to
+#         "DBH".
+#
+#expf:    Character string corresponding to name of column pertaining to TPA of
+#         tree records in data argument. By default, this argument is set to
+#         "TPA".
+#
+#ht:      Character string corresponding to name of column pertaining to Ht of
+#         tree records in data argument. By default, this argument is set to
+#         "Ht".
+#
+#TPA:     TPA of stand/plot.
+#
+#BA:      Basal area of stand/plot.
+#
+#plotvals: Named list containing plot attributes for each species in plot/stand and/or
+#across all species in plot/stand.
+#
+#debug:	  Logical variable used to specify if debug output should be printed to
+#         R console. If value is TRUE, then debug output will printed to R
+#         console.
+#
+#con:     Connection to database defined in input
+#
+#Return value
+#
+#Named list containing
+# - STSIM potential vegetation type grouping (VEGTYPE)
+# - R1 Cover Type (COVERTYPE_R1),
+# - Dominance group (DOM6040),
+# - number of Canopy layers (VERTICAL STRUCTURE)--1,2,3 or continuous (C)
+# - Basal area weighted diameter size class (SIZECLASS_NTG)
+# - size and density-based structure class strata (STRCLSSTR)
+################################################################################
+#'@export
+R1<-function(data,
+                  stand = "StandID",
+                  species = "SpeciesPLANTS",
+                  dbh = "DBH",
+                  expf = "TPA",
+                  ht = "Ht",
+                  TPA,
+                  BA,
+                  plotvals,
+                  debug = F,
+                  con=con){
+
+  #Calculate the number of trees in the output treelist for the plot
+  Ntrees <- length(data$SpeciesPLANTS)
+
+  #Initialize results vector to NA
+  results=list("VEGTYPE" = NA,
+               "COVERTYPE_R1" = NA,
+               "DOM6040" = NA,
+               "VERTICAL_STRUCTURE" = NA,
+               "SIZECLASS_NTG" = NA,
+               "STRCLSSTR" = NA)
+
+  #Check for required R1HABTYPE compute variable that should contain the
+  #3-digit numeric ADP habitat type code
+  if(!RSQLite::dbExistsTable(con, "FVS_Compute")){
+    stop(paste("FVS_Compute table is missing in the output database and region=1.",
+         "The R1HABTYPE compute variable is needed for R1 classification.","\n"))
+  }
+  #Establish connection to output database
+  #conR1<-RSQLite::dbConnect(RSQLite::SQLite(), "C:/20230106/Project_1/FVSOut.db")
+  #check if FVS_compute table exists
+  if(RSQLite::dbExistsTable(con, "FVS_Compute")){
+    HABTYPE <- ""
+    cat("FVS_Compute table exists for R1HABTYP query", "\n")
+    query<- paste("SELECT R1HABTYP", "FROM FVS_Compute")
+
+    #Add quotes to stand and commas to cases
+    cases<-paste0("'",data$CaseID[1],"'", ",")
+    #Collapse cases into a single string
+    cases<-paste(cases, collapse = "")
+    #Remove last comma from cases
+    cases<-substr(cases,1, nchar(cases)-1)
+    #Add parentheses around cases
+    cases<-paste0("(", cases, ")")
+    #Create WHERE clause with cases
+    standQuery<-paste0("WHERE CaseID IN", cases)
+    #Add standQuery to query
+    query<-paste(query, standQuery)
+
+    habquery <- try(RSQLite::dbGetQuery(con, query))
+    if(class(habquery) != "try-error") {
+      cat("R1HABTYP exists as",habquery[[1]][1], "\n")
+      HABTYPE <- habquery[[1]][1]
+    }
+    else{
+      stop(paste("R1HABTYPE compute variable needed for R1 classification is
+          missing from the FVS_Compute table.","\n"))
+    }
+  }
+
+  #Check for missing columns in data
+  missing <- c(stand, species, dbh, expf, ht) %in% colnames(data)
+
+  #If name of columns provided in stand, species, dbh, expf, and ht  are not
+  #found in data warning message is issued and NA values are returned.
+  if(F %in% missing)
+  {
+    cat("One or more input arguments not found in data. Check spelling.", "\n")
+    return(results)
+  }
+
+  #Print stand
+  if(debug)
+  {
+    cat("In function R1", "\n")
+    cat("Stand:", unique(data[[stand]]), "\n")
+    cat("Columns:", "\n",
+                "stand:", stand, "\n",
+                "species:", species, "\n",
+                "dbh:", dbh, "\n",
+                "expf:", expf, "\n",
+                "ht:", ht, "\n","\n")
+  }
+  #Initialize return attribute variables as NA
+  VEGTYPE<-NA
+  COVERTYPE_R1<-NA
+  DOM6040<-NA
+  VERTICAL_STRUCTURE<-NA
+
+  #Print plot BA and TPA if debug is TRUE
+  if(debug) cat("BA of plot is", BA, "\n")
+  if(debug) cat("TPA of plot is", TPA, "\n")
+
+  #Stand-level basal area weighted diameter
+  StBAWTDBH <- round(plotvals[["ALL"]]["BA_WT_DIA"][[1]][1],2)
+
+  #Stand-level canopy cover percent
+  StCC <- round(plotvals[["ALL"]]["CC"][[1]][1],2)
+
+## Initialize the species-level vectors
+  #Identify unique species in stand
+  spStand <- unique(data$SpeciesPLANTS)
+  #Initialize vector that will store TPA value for each species
+  SpeciesTPA <- vector("numeric", length(spStand))
+  #Initialize vector that will store BA value for each species
+  SpeciesBA <- vector("numeric", length(spStand))
+  #Initialize vector that will store proportion of TPA value for each species
+  SpeciesPropTPA <- vector("numeric", length(spStand))
+  #Initialize vector that will store proportion of BA value for each species
+  SpeciesPropBA <- vector("numeric", length(spStand))
+  #Initialize vector that will store a total height value for each species
+  SpeciesTotalHeight <- vector("numeric", length(spStand))
+  #Initialize vector that will store a BA weighted DBH value for each species
+  BAWghtDiamBySpecies <- vector("numeric", length(spStand))
+  #Initialize vector that will store a BA weighted height value for each species
+  BAWghtHeightBySpecies <- vector("numeric", length(spStand))
+  #Initialize vector that will store an average height value for each species
+  AvgHeightBySpecies <- vector("numeric", length(spStand))
+
+  #Initialize diameter class vector
+  BAByDiameterClass <- vector("numeric",6)
+
+  #Populate BAByDiameterClass vector
+  for (i in 1:Ntrees){
+    if(data$DBH[i] >= 0.0 && data$DBH[i] < 5.0)
+      BAByDiameterClass[1] <- BAByDiameterClass[1] + data$TREEBA[i]
+    if(data$DBH[i] >= 5.0 && data$DBH[i] < 10.0)
+      BAByDiameterClass[2] <- BAByDiameterClass[2] + data$TREEBA[i]
+    if(data$DBH[i] >= 10.0 && data$DBH[i] < 15.0)
+      BAByDiameterClass[3] <- BAByDiameterClass[3] + data$TREEBA[i]
+    if(data$DBH[i] >= 15.0 && data$DBH[i] < 20.0)
+      BAByDiameterClass[4] <- BAByDiameterClass[4] + data$TREEBA[i]
+    if(data$DBH[i] >= 20.0 && data$DBH[i] < 25.0)
+      BAByDiameterClass[5] <- BAByDiameterClass[5] + data$TREEBA[i]
+    if(data$DBH[i] >= 25.0)
+      BAByDiameterClass[6] <- BAByDiameterClass[6] + data$TREEBA[i]
+  }
+
+  #Weight BAByDiameterClass vector by BA
+  for (jdiam in 1:length(BAByDiameterClass) ){
+    BAByDiameterClass[jdiam] <- round((BAByDiameterClass[jdiam]/BA),2)
+  }
+
+  #Populate the species-level vectors
+  #SpeciesTPA
+  for(i in 1:length(spStand)){
+    SpeciesTPA[i] <- plotvals[[spStand[i]]]["TPA"]
+  }
+  #SpeciesBA
+  for(i in 1:length(spStand)){
+    SpeciesBA[i] <- plotvals[[spStand[i]]]["BA"]
+  }
+  #SpeciesTotalHeight
+  for(i in 1:length(spStand)){
+    SpeciesTotalHeight[i] <- plotvals[[spStand[i]]]["SUM_HT"]
+  }
+  #SpeciesPropTPA
+  for(i in 1:length(spStand)){
+    SpeciesPropTPA[i] <- SpeciesTPA[i]/TPA
+  }
+  #SpeciesPropBA
+  for(i in 1:length(spStand)){
+    SpeciesPropBA[i] <- SpeciesBA[i]/BA
+  }
+  #BAWghtDiamBySpecies
+  for(i in 1:length(spStand)){
+    BAWghtDiamBySpecies[i] <- plotvals[[spStand[i]]]["BA_WT_DIA"]
+  }
+  #BAWghtHeightBySpecies
+  for(i in 1:length(spStand)){
+    BAWghtHeightBySpecies[i] <- plotvals[[spStand[i]]]["BA_WT_HT"]
+  }
+  #AvgHeightBySpecies
+  for(i in 1:length(spStand)){
+    AvgHeightBySpecies[i] <- SpeciesTotalHeight[i]/SpeciesTPA[i]
+    if(is.na(AvgHeightBySpecies[i])) AvgHeightBySpecies[i] <- 0
+  }
+
+  #If debug, print the values above
+  if(debug)
+  {
+    cat("Species in stand:", spStand, "\n")
+    cat("Species TPA in stand:", SpeciesTPA, "\n")
+    cat("Species BA in stand:", SpeciesBA, "\n")
+    cat("Species Total Height in the stand:", SpeciesTotalHeight, "\n")
+    cat("Species proportion of TPA:", SpeciesPropTPA, "\n")
+    cat("Species proportion of BA:", SpeciesPropBA, "\n")
+    cat("Species BAWTDBH:", BAWghtDiamBySpecies, "\n")
+    cat("Species BAWTHT:", BAWghtHeightBySpecies, "\n")
+    cat("Species average height:", AvgHeightBySpecies, "\n")
+  }
+
+  if(BA < 20 && TPA > 100){
+    DOM6040 <- computeDominance6040(TPA,spStand,SpeciesPropTPA,BAWghtDiamBySpecies,
+                      AvgHeightBySpecies)
+  }else if(BA > 20){
+    DOM6040 <- computeDominance6040(BA,spStand,SpeciesPropBA,BAWghtDiamBySpecies,
+                      BAWghtHeightBySpecies)
+  }else{
+    DOM6040 <- "NONE"
+  }
+
+MapDominance6040toCovertype <- c(
+   "ABGR"="mixedmesiccon", "ABGR-IMIX"="mixedmesiccon",
+   "ABGR-TMIX"="mixedmesiccon", "ABGR-HMIX"="mixedmesiccon",
+   "ABLA"="sprucefir", "ABLA-IMIX"="sprucefir",
+   "ABLA-TMIX"="sprucefir", "ABLA-HMIX"="sprucefir", "ACER"="aspenhardwood",
+   "ACER-IMIX"="aspenhardwood","ACER-TMIX"="aspenhardwood",
+   "BEPA"="aspenhardwood", "BEPA-IMIX"="aspenhardwood",
+   "BEPA-TMIX"="aspenhardwood", "BEPA-HMIX"="aspenhardwood",
+   "CELE3"="dryshrub", "CELE3-IMIX"="dryshrub",
+   "CELE3-TMIX"="dryshrub", "CELE3-HMIX"="dryshrub",
+   "JUNIP"="ponderosapine", "JUNIP-IMIX"="ponderosapine",
+   "JUNIP-TMIX"="ponderosapine", "JUNIP-HMIX"="ponderosapine",
+   "LALY"="whitebarksubalpinelarch", "LALY-IMIX"="whitebarksubalpinelarch",
+   "LALY-TMIX"="whitebarksubalpinelarch", "LALY-HMIX"="whitebarksubalpinelarch",
+   "LAOC"="wlarchmixedcon", "LAOC-IMIX"="wlarchmixedcon",
+   "LAOC-TMIX"="wlarchmixedcon", "LAOC-HMIX"="wlarchmixedcon",
+   "PIAL"="whitebarksubalpinelarch", "PIAL-IMIX"="whitebarksubalpinelarch",
+   "PIAL-TMIX"="whitebarksubalpinelarch", "PIAL-HMIX"="whitebarksubalpinelarch",
+   "PICO"="lodgepolepine", "PICO-IMIX"="lodgepolepine",
+   "PICO-TMIX"="lodgepolepine", "PICO-HMIX"="lodgepolepine",
+   "PIEN"="sprucefir", "PIEN-IMIX"="sprucefir",
+   "PIEN-TMIX"="sprucefir", "PIEN-HMIX"="sprucefir",
+   "PIFL2"="ponderosapine", "PIFL2-IMIX"="ponderosapine",
+   "PIFL2-TMIX"="ponderosapine", "PIFL2-HMIX"="ponderosapine",
+   "PIMO3"="mixedmesiccon", "PIMO3-IMIX"="mixedmesiccon",
+   "PIMO3-TMIX"="mixedmesiccon", "PIMO3-HMIX"="mixedmesiccon",
+   "PIPO"="ponderosapine", "PIPO-IMIX"="ponderosapine",
+   "PIPO-TMIX"="ponderosapine", "PIPO-HMIX"="ponderosapine",
+   "POPUL"="aspenhardwood", "POPUL-IMIX"="aspenhardwood",
+   "POPUL-TMIX"="aspenhardwood", "POPUL-HMIX"="aspenhardwood",
+   "POTR5"="aspenhardwood", "POTR5-IMIX"="aspenhardwood",
+   "POTR5-TMIX"="aspenhardwood", "POTR5-HMIX"="aspenhardwood",
+   "PSME"="mixedmesiccon", "PSME-IMIX"="mixedmesiccon",
+   "PSME-TMIX"="mixedmesiccon", "PSME-HMIX"="mixedmesiccon",
+   "TABR2"="sprucefir", "TABR2-IMIX"="sprucefir",
+   "TABR2-TMIX"="sprucefir", "TABR2-HMIX"="sprucefir",
+   "THPL"="mixedmesiccon", "THPL-IMIX"="mixedmesiccon",
+   "THPL-TMIX"="mixedmesiccon", "THPL-HMIX"="mixedmesiccon",
+   "TSHE"="mixedmesiccon", "TSHE-IMIX"="mixedmesiccon",
+   "TSHE-TMIX"="mixedmesiccon", "TSHE-HMIX"="mixedmesiccon",
+   "TSME"="mixedmesiccon", "TSME-IMIX"="mixedmesiccon",
+   "TSME-TMIX"="mixedmesiccon", "TSME-HMIX"="mixedmesiccon",
+   "IMIX"="mixedmesiccon", "TMIX"="mixedmesiccon",
+   "HMIX"="aspenhardwood", "FRPE"="aspenhardwood",
+   "FRPE-IMIX"="aspenhardwood", "FRPE-TMIX"="aspenhardwood",
+   "FRPE-HMIX"="aspenhardwood", "NONE"="NONE"
+  )
+
+ #compute CoverType
+  COVERTYPE_R1 <- as.character(MapDominance6040toCovertype[DOM6040])
+
+  if(!is.na(COVERTYPE_R1) && COVERTYPE_R1=="mixedmesiccon"){
+    Hot_Dry <- c(
+      "000", "040" ,"050" ,"051" ,"052",
+      "070" ,"090" ,"091" ,"092" ,"093",
+      "094" ,"095")
+    Warm_Dry <- c(
+      "100", "110", "130", "140",
+      "141", "142", "160", "161",
+      "162", "103", "104", "100032",
+      "100033", "100034", "100035", "100037",
+      "105", "106", "150", "200",
+      "210", "220", "230", "205",
+      "390", "311", "380", "321",
+      "180", "181", "182")
+
+    switchToDDF <- match(HABTYPE, Hot_Dry)
+    if(is.na(switchToDDF)) switchToDDF <- match(HABTYPE, Warm_Dry)
+    if(!is.na(switchToDDF) && COVERTYPE_R1=="mixedmesiccon"){
+      COVERTYPE_R1 <- "dryDouglasfir"
+    }
+  }
+
+  #compute VERTICAL_STRUCTURE
+  if(BA < 20 && TPA < 100){
+    VERTICAL_STRUCTURE <- "NONE"
+  }
+  else if(BA < 20 && TPA >= 100){
+    VERTICAL_STRUCTURE <- 1
+  }
+  else {
+    VERTICAL_STRUCTURE <- computeVerticalStructure(BAByDiameterClass)
+  }
+
+  MapADPtoStSimPVT <- c(
+    "110"="HODR","130"="HODR","140"="HODR","141"="HODR",
+    "142"="HODR","160"="HODR","161"="HODR","162"="HODR",
+    "170"="HODR","171"="HODR","172"="HODR","180"="HODR",
+    "181"="HODR","182"="HODR","190"="HODR","200"="HODR",
+    "210"="HODR","220"="HODR","230"="HODR","250"="WMMW",
+    "260"="WMMW","261"="WMMW","262"="WMMW","263"="WMMW",
+    "280"="WMMW","281"="WMMW","282"="WMMW","283"="WMMW",
+    "290"="WMMW","291"="WMMW","292"="WMMW","293"="WMMW",
+    "310"="WMMW","311"="HODR","312"="WMMW","313"="WMMW",
+    "320"="WMMW","321"="HODR","322"="WMMW","323"="WMMW",
+    "324"="HODR","330"="WMMW","340"="WMMW","350"="WMMW",
+    "360"="WMMW","370"="WMMW","380"="HODR","400"="COOL",
+    "410"="COOL","420"="COOL","421"="COOL","422"="COOL",
+    "430"="WMMW","440"="COOL","450"="COOL","460"="COOL",
+    "461"="COOL","462"="COOL","470"="COOL","480"="COOL",
+    "500"="COOL","501"="WAMO","505"="WMMW","506"="WMMW",
+    "507"="WMMW","508"="WMMW","510"="WMMW","511"="WMMW",
+    "512"="WMMW","515"="WMMW","516"="WAMO","517"="WAMO",
+    "518"="WAMO","519"="WAMO","520"="WAMO","521"="WAMO",
+    "522"="WAMO","523"="WAMO","524"="WAMO","525"="WAMO",
+    "526"="WAMO","529"="WAMO","530"="WAMO","531"="WAMO",
+    "532"="WAMO","533"="WAMO","534"="WAMO","535"="WAMO",
+    "540"="WAMO","541"="WAMO","542"="WAMO","545"="WAMO",
+    "546"="WAMO","547"="WAMO","548"="WAMO","550"="WAMO",
+    "555"="WAMO","560"="WAMO","565"="WAMO","570"="WAMO",
+    "571"="WAMO","572"="WAMO","573"="WAMO","574"="WAMO",
+    "575"="WAMO","576"="WAMO","577"="WAMO","578"="WAMO",
+    "579"="WAMO","590"="WMMW","591"="WMMW","592"="WMMW",
+    "600"="COOL","610"="COOL","620"="COOL","621"="COOL",
+    "622"="COOL","623"="COOL","624"="COOL","625"="COOL",
+    "630"="COOL","635"="COOL","636"="COOL","637"="COOL",
+    "640"="COOL","650"="COOL","651"="COOL","652"="COOL",
+    "653"="COOL","654"="COOL","655"="COOL","660"="COOL",
+    "661"="COOL","662"="COOL","663"="COOL","670"="COOL",
+    "671"="COOL","672"="COLD","673"="COOL","674"="COLD",
+    "675"="COOL","676"="COLD","677"="COOL","680"="COOL",
+    "681"="COLD","682"="COOL","685"="COOL","686"="COOL",
+    "687"="COOL","690"="COOL","691"="COOL","692"="COLD",
+    "693"="COOL","694"="COLD","700"="COLD","710"="COOL",
+    "711"="COLD","712"="COOL","713"="COLD","720"="COOL",
+    "730"="COLD","731"="COLD","732"="COLD","733"="COLD",
+    "740"="COOL","750"="COOL","770"="COOL","780"="COOL",
+    "790"="COOL","791"="COOL","792"="COOL","800"="COOL",
+    "810"="COLD","820"="COLD","830"="COLD","831"="COLD",
+    "832"="COLD","840"="COLD","841"="COLD","842"="COLD",
+    "850"="COLD","860"="COLD","870"="COLD","890"="COLD",
+    "900"="COLD","910"="WMMW","920"="COOL","930"="COOL",
+    "940"="COLD","950"="COOL", "100032"="HODR","100033"="HODR",
+    "100034"="HODR","100035"="HODR","100037"="HODR"
+  )
+
+  #compute VEGTYPE
+  if(HABTYPE!=""){
+    #map R1HABTYP to StSimPVT
+    PVT <- as.character(MapADPtoStSimPVT[as.character(HABTYPE)])
+
+    AbbreviateCovertype <- c(
+      "mixedmesiccon"="MMC","sprucefir"="SAF","aspenhardwood"="ASH",
+      "dryshrub"="DSH","ponderosapine"="POP","whitebarksubalpinelarch"="WBP",
+      "wlarchmixedcon"="LMC","lodgepolepine"="LPP","dryDouglasfir"="DDF",
+      "NONE"="NONE")
+
+    #Abbreviate COVERTYPE_R1
+    COVABBR <- as.character(AbbreviateCovertype[COVERTYPE_R1])
+
+    #Concatenate StSimPVT with the abbreviation of COVERTYPE_R1
+    VEGTYPE <- paste0(PVT,"-",COVABBR)
+  }
+
+  #compute SIZECLASS_NTG
+  if(!is.na(StBAWTDBH) || !is.null(StBAWTDBH)){
+    if(StBAWTDBH <=0.1){
+      SIZECLASS_NTG <- "Seedling"
+    }
+    if (StBAWTDBH > 0.1 && StBAWTDBH < 5.0){
+      SIZECLASS_NTG <- "00.1-04.9"
+    }
+    if (StBAWTDBH >= 5.0 && StBAWTDBH < 10.0){
+      SIZECLASS_NTG <- "05.0-09.9"
+    }
+    if (StBAWTDBH >= 10.0 && StBAWTDBH < 15.0){
+      SIZECLASS_NTG <- "10.0-14.9"
+    }
+    if (StBAWTDBH >= 15.0 && StBAWTDBH < 20.0){
+      SIZECLASS_NTG <- "15.0-19.9"
+    }
+    if (StBAWTDBH >= 20.0 && StBAWTDBH < 25.0){
+      SIZECLASS_NTG <- "20.0-24.9"
+    }
+    if (StBAWTDBH >= 25.0){
+      SIZECLASS_NTG <- "25.0+"
+    }
+  }
+
+  #compute structure class strata STRCLSSTR variable
+  if(!is.na(StBAWTDBH) && !is.na(StCC)){
+    if(StCC<10) STRCLSSTR <- "X"
+    if(StBAWTDBH>=0 && StBAWTDBH<5){#0-4.9"
+      STRCLSSTR <- if(StCC<40) "E" else "F"
+    }
+    if(StBAWTDBH>=5 && StBAWTDBH<10){#5-9.9"
+      STRCLSSTR <- if(StCC<40) "G" else "H"
+    }
+    if(StBAWTDBH>=10 && StBAWTDBH<15){#10-14.9"
+      if(StCC>=10 && StCC<40){
+        STRCLSSTR <- "I"
+      } else if (StCC>=40 && StCC<60){
+        STRCLSSTR <- "J"
+      } else STRCLSSTR <- "K"
+    }
+    if(StBAWTDBH>=15&& StBAWTDBH<20){#15-19.9"
+      if(StCC>=10 && StCC<40){
+        STRCLSSTR <- "L"
+      } else if (StCC>=40 && StCC<60){
+        STRCLSSTR <- "M"
+      } else STRCLSSTR <- "N"
+    }
+    if(StBAWTDBH>=20){#20"+
+      if(StCC>=10 && StCC<40){
+        STRCLSSTR <- "O"
+      } else if (StCC>=40 && StCC<60){
+        STRCLSSTR <- "P"
+      } else STRCLSSTR <- "Q"
+    }
+  }
+
+  results=list("VEGTYPE" = VEGTYPE,
+               "COVERTYPE_R1" = COVERTYPE_R1,
+               "DOM6040" = DOM6040,
+               "VERTICAL_STRUCTURE" = VERTICAL_STRUCTURE,
+               "SIZECLASS_NTG" = SIZECLASS_NTG,
+               "STRCLSSTR" = STRCLSSTR)
+
+  return(results)
+}

--- a/packages/vegClass/R/computeVerticalStructure.R
+++ b/packages/vegClass/R/computeVerticalStructure.R
@@ -1,0 +1,48 @@
+################################################################################
+#Function: computeVerticalStructure
+#
+#Calculates the number of canopy layers
+#
+#Argument
+#
+#BAByDiameterClass: vector containing the amount of basal area by diameter class.
+#         Classes are 0-4.9", 5-9.9", 10-14.9", 15-19.9", 20-24.9", and 25"+
+#
+#Return value
+#
+# - number of Canopy layers (VERTICAL STRUCTURE)--1,2,3 or continuous (C)
+################################################################################
+#'@export
+computeVerticalStructure <- function(BAByDiameterClass){
+      num35 <- 1
+      for(index9 in 6:3){
+        if(BAByDiameterClass[index9] >= 0.02 && BAByDiameterClass[index9-2] >= 0.02 &&
+           BAByDiameterClass[index9] >= (1.8*BAByDiameterClass[index9-1]) &&
+           BAByDiameterClass[index9-2] >= (1.8*BAByDiameterClass[index9-1])) num35 <- num35+1
+      }
+      if(num35==1){
+        for(index10 in 6:4){
+          if(abs(BAByDiameterClass[index10-1]-BAByDiameterClass[index10-2]) <= 0.1 &&
+             BAByDiameterClass[index10] >= 0.02 &&
+             BAByDiameterClass[index10-3] >= 0.02 &&
+             0.9*(BAByDiameterClass[index10-1]+BAByDiameterClass[index10-2]) <= BAByDiameterClass[index10] &&
+             0.9*BAByDiameterClass[index10-1]+BAByDiameterClass[index10-2] <= BAByDiameterClass[index10-3]) num35 <- num35+1
+        }
+      }
+      if(num35==1){
+        num36 <- 0
+        for(index11 in 1:length(BAByDiameterClass)){
+          if(BAByDiameterClass[index11] >= 0.02) num36 <- num36+1
+          VERTICAL_STRUCTURE <- "C"
+          if(num36 < 5 &&
+           (BAByDiameterClass[1] < 0.02 ||
+            BAByDiameterClass[2] < 0.02 ||
+            BAByDiameterClass[3] < 0.02)) VERTICAL_STRUCTURE <- as.character(num35)
+        }
+      }
+      else {
+        VERTICAL_STRUCTURE <- "C"
+        if(num35 <= 3) VERTICAL_STRUCTURE <- as.character(num35)
+      }
+      return(VERTICAL_STRUCTURE)
+}

--- a/packages/vegClass/R/dbInput.R
+++ b/packages/vegClass/R/dbInput.R
@@ -370,7 +370,7 @@ caseQuery <- function(runTitle)
   query<- paste("SELECT FVS_Cases.StandID, FVS_Cases.CaseID, FVS_Cases.Groups,",
                 "FVS_Cases.Variant",
                 "FROM FVS_Cases",
-                "WHERE RunTitle LIKE", paste0("'%",runTitle,"%'"))
+                "WHERE RunTitle LIKE", paste0("'",runTitle,"'"))
   return(query)
 }
 

--- a/packages/vegClass/R/main.R
+++ b/packages/vegClass/R/main.R
@@ -520,7 +520,6 @@ main<- function(input = NULL,
       #Execute SQL query to obtain list of stand data
       standDF<-RSQLite::dbGetQuery(con,
                                    dbQuery)
-
       #Display column names and number of rows in standDF
       cat("Columns read from tree list:", colnames(standDF), "\n")
       cat("Number of rows read from tree list:", nrow(standDF), "\n")
@@ -607,7 +606,7 @@ main<- function(input = NULL,
         }
 
         #Calculate basal and percent canopy cover for each tree record
-        standYrDF$TREEBA <- standYrDF$DBH^2 * standYrDF$TPA * 0.005454
+        standYrDF$TREEBA <- standYrDF$DBH^2 * standYrDF$TPA * 0.0054542
         standYrDF$TREECC <- pi * (standYrDF$CrWidth/2)^2 *
           (standYrDF$TPA/43560) * 100
 
@@ -618,10 +617,9 @@ main<- function(input = NULL,
                              VARIANT = variant,
                              REGION = region,
                              YEAR = years[j])
-
         #Bind data from vegOut to yrOutput
         yrOutput <- cbind(yrOutput,
-                          vegOut(standYrDF))
+                          vegOut(standYrDF,region=region,con=con))
 
         #If addVolume is TRUE, calculate volumes and add to yrOutput
         if(addVolume)
@@ -682,7 +680,6 @@ main<- function(input = NULL,
         standSum<-standSum + 1
         next
       }
-
       #Combine all year-by-year information for standID into a single
       #dataframe.
       standOut<-do.call("rbind", standYrOutput)

--- a/packages/vegClass/R/plotAttr.R
+++ b/packages/vegClass/R/plotAttr.R
@@ -210,6 +210,9 @@
 #Reineke SDI (RSDI)
 #Basal area weighted diameter (BA_WT_DIA)
 #Basal area weighted height (BA_WT_HT)
+#Sum of total heights per acre (SUM_HT)--for later use in R1.R in calculating
+#average height by species by dividing each SUM_HT by each species' respective
+#TPA value
 #
 #Arguments:
 #
@@ -307,7 +310,8 @@ plotAttr <- function(data,
                        "ZSDI" = 0,
                        "RSDI" = 0,
                        "BA_WT_DIA" = 0,
-                       "BA_WT_HT" = 0))
+                       "BA_WT_HT" = 0,
+                       "SUM_HT" = 0))
 
     return(attr)
   }
@@ -348,7 +352,8 @@ plotAttr <- function(data,
               "ZSDI" = 0,
               "RSDI" = 0,
               "BA_WT_DIA" = 0,
-              "BA_WT_HT" = 0)
+              "BA_WT_HT" = 0,
+              "SUM_HT" = 0)
 
     #Store attr in attrList
     attrList[[i]] <- attr
@@ -358,11 +363,13 @@ plotAttr <- function(data,
   #SDI), BAWTD, and BAWTH
   TBA = 0
   TEXPF = 0
+  THT = 0
   DBHSQ = 0
   TCC = 0
   TZSDI = 0
   BAWTD = 0
   BAWTH = 0
+  TSUMHT = 0
 
   #Loop across data and calculate attributes
   for(i in 1:nrow(data))
@@ -379,8 +386,11 @@ plotAttr <- function(data,
       #Extract DBH of tree i
       DBH <- data[[dbh]][i]
 
+      #Extract HT of tree i
+      THT <- data[[ht]][i]
+
       #Calculate BA of tree
-      TBA <- DBH^2 * TEXPF * 0.005454
+      TBA <- DBH^2 * TEXPF * 0.0054542
 
       #Calculate CC of tree
       TCC <- pi * (data[[crwidth]][i]/2)^2 *(TEXPF/43560) * 100
@@ -397,17 +407,22 @@ plotAttr <- function(data,
       #Calculate tree contribution of ZSDI
       TZSDI <- (TEXPF * (DBH/10)^1.605)
 
+      #Calculate tree contribution of SUM_HT
+      TSUMHT <- THT * TEXPF
+
       if(debug)
       {
         cat("SPECIES:", sp, "\n",
             "TREE DBH:", DBH, "\n",
             "TREE EXP:", TEXPF, "\n",
+            "TREE HT:", THT, "\n",
             "TREECC:", TCC, "\n",
             "TREEBA:", TBA, "\n",
             "DBHSQ:", DBHSQ, "\n",
             "BAWTD:", BAWTD, "\n",
             "BAWTH:", BAWTH, "\n",
-            "TZSDI:", TZSDI, "\n", "\n")
+            "TZSDI:", TZSDI, "\n",
+            "TSUMHT:", TSUMHT, "\n","\n")
       }
 
       #=========================================================================
@@ -435,6 +450,9 @@ plotAttr <- function(data,
       #Update ZSDI
       attrList[["ALL"]]["ZSDI"] <- attrList[["ALL"]]["ZSDI"] + TZSDI
 
+      #Update SUM_HT
+      attrList[["ALL"]]["SUM_HT"] <- attrList[["ALL"]]["SUM_HT"] + TSUMHT
+
       #=========================================================================
       #Update values for species (sp) if allSpecies is TRUE
       #=========================================================================
@@ -461,6 +479,9 @@ plotAttr <- function(data,
 
         #Update ZSDI
         attrList[[sp]]["ZSDI"] <- attrList[[sp]]["ZSDI"] + TZSDI
+
+        #Update SUM_HT
+        attrList[[sp]]["SUM_HT"] <- attrList[[sp]]["SUM_HT"] + TSUMHT
       }
     }
   }


### PR DESCRIPTION
Existing vegClass files changed

dbInput.R
• Changed the caseQuery function to use exact, rather than partial, matches for run titles in the FVS_Cases table.

vegOut.R
• Added USFS Region # and input database connection variables to the vegOut function • Added region specific output dataframe variables for USFS Region 1 plotAttr.R
• Added SUM_HT variables to the list of attributes to be returned • Changed the “Forester’s Constant” to be 0.0054542 (consistent with R1 classifier code) as opposed to 0.005454

Main.R
• Changed the “Forester’s Constant” to be 0.0054542 (consistent with R1 classifier code) as opposed to 0.005454 • Added the 2 new variables (region and con—see above) to the vegOut function call

R1-specific files added

• R1.R: Calculates several of the variables previously available in the legacy R1 Existing Vegetation Classifier post-processor to FVS, and a couple new ones.

• DOM6040.R: Calculates dominance group 6040

• computeVerticalStructure.R: Calculates the number of canopy layers-- 1,2,3 or continuous (C)